### PR TITLE
Add property-based subtests for Squidge()

### DIFF
--- a/squidge/squidge_test.go
+++ b/squidge/squidge_test.go
@@ -1,6 +1,9 @@
 package squidge
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSquidge(t *testing.T) {
 	got := Squidge()
@@ -8,4 +11,27 @@ func TestSquidge(t *testing.T) {
 	if got != want {
 		t.Errorf("got %q, wanted %q", got, want)
 	}
+}
+
+func TestSquidgeProperties(t *testing.T) {
+	out := Squidge()
+
+	t.Run("non-empty", func(t *testing.T) {
+		if out == "" {
+			t.Error("Squidge() returned empty string")
+		}
+	})
+
+	t.Run("ends with bang", func(t *testing.T) {
+		if !strings.HasSuffix(out, "!") {
+			t.Errorf("Squidge() = %q, want suffix %q", out, "!")
+		}
+	})
+
+	t.Run("starts capitalized", func(t *testing.T) {
+		first := out[:1]
+		if first != strings.ToUpper(first) {
+			t.Errorf("Squidge() = %q, want first char to be uppercase", out)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Adds `TestSquidgeProperties` with three subtests asserting the output of
`Squidge()` is non-empty, ends with `!`, and starts with an uppercase
letter.

Pure additive change; no production code modified. Local `go test -v`
passes:

```
=== RUN   TestSquidge
--- PASS: TestSquidge (0.00s)
=== RUN   TestSquidgeProperties
=== RUN   TestSquidgeProperties/non-empty
=== RUN   TestSquidgeProperties/ends_with_bang
=== RUN   TestSquidgeProperties/starts_capitalized
--- PASS: TestSquidgeProperties (0.00s)
PASS
```

## Test plan

- [ ] `Go Tests` workflow runs and is green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)